### PR TITLE
refactor: simplify user-service configuration and include shared code

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres123
     ports:
-    - "5433:5432"
+      - '5433:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
     networks:
@@ -61,13 +61,14 @@ services:
     volumes:
       - ./microservices/api-gateway:/app
       - /app/node_modules
+      - ./shared:/shared
     command: npm run start:dev
 
   # User Service
   user-service:
     build:
-      context: ./microservices/user-service
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: microservices/user-service/Dockerfile
     container_name: user-service
     ports:
       - '3001:3001'
@@ -86,6 +87,7 @@ services:
     volumes:
       - ./microservices/user-service:/app
       - /app/node_modules
+      - ./shared:/shared
     command: npm run start:dev
 
   # Product Service

--- a/microservices/user-service/Dockerfile
+++ b/microservices/user-service/Dockerfile
@@ -3,13 +3,16 @@ FROM node:20-alpine
 WORKDIR /app
 
 # Copiar archivos de dependencias
-COPY package*.json ./
+COPY microservices/user-service/package*.json ./
 
 # Instalar dependencias
 RUN npm install --legacy-peer-deps
 
-# Copiar código fuente
-COPY . .
+# Copiar código fuente del microservicio
+COPY microservices/user-service ./
+
+# Copiar código compartido
+COPY shared /shared
 
 # Compilar la aplicación
 RUN npm run build

--- a/microservices/user-service/src/app.module.ts
+++ b/microservices/user-service/src/app.module.ts
@@ -2,7 +2,6 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
-import { ConfigModule, ConfigService } from '@nestjs/config';
 
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
@@ -13,19 +12,12 @@ import { getJwtConfig } from './config/jwt.config';
 
 @Module({
   imports: [
-    ConfigModule.forRoot({ isGlobal: true }),
-
     TypeOrmModule.forRootAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
       useFactory: getDatabaseConfig,
     }),
 
     PassportModule,
-
     JwtModule.registerAsync({
-      imports: [ConfigModule],
-      inject: [ConfigService],
       useFactory: getJwtConfig,
     }),
 

--- a/microservices/user-service/src/common/interfaces/api-response.interface.ts
+++ b/microservices/user-service/src/common/interfaces/api-response.interface.ts
@@ -1,0 +1,26 @@
+export interface ApiResponse<T = any> {
+  success: boolean;
+  message?: string;
+  data?: T;
+  error?: string;
+  statusCode?: number;
+  timestamp?: string;
+}
+
+export interface PaginatedResponse<T = any> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  totalPages: number;
+}
+
+export interface ServiceHealth {
+  status: 'ok' | 'error';
+  service: string;
+  timestamp: string;
+  uptime: number;
+  database?: string;
+  websockets?: string;
+  redis?: string;
+}

--- a/microservices/user-service/src/config/database.config.ts
+++ b/microservices/user-service/src/config/database.config.ts
@@ -1,18 +1,15 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
-import { ConfigService } from '@nestjs/config';
 import { User } from '../modules/user/entities/user.entity';
 
-export const getDatabaseConfig = (
-  configService: ConfigService,
-): TypeOrmModuleOptions => ({
+export const getDatabaseConfig = (): TypeOrmModuleOptions => ({
   type: 'postgres',
-  host: configService.get<string>('DATABASE_HOST', 'localhost'),
-  port: parseInt(configService.get<string>('DATABASE_PORT', '5432'), 10),
-  username: configService.get<string>('DATABASE_USER', 'postgres'),
-  password: configService.get<string>('DATABASE_PASSWORD', 'postgres123'),
-  database: configService.get<string>('DATABASE_NAME', 'userdb'),
-  entities: [User], 
-  synchronize: configService.get<string>('NODE_ENV') === 'development',
-  logging: configService.get<string>('NODE_ENV') === 'development',
+  host: process.env.DATABASE_HOST ?? 'localhost',
+  port: parseInt(process.env.DATABASE_PORT ?? '5432', 10),
+  username: process.env.DATABASE_USER ?? 'postgres',
+  password: process.env.DATABASE_PASSWORD ?? 'postgres123',
+  database: process.env.DATABASE_NAME ?? 'userdb',
+  entities: [User],
+  synchronize: process.env.NODE_ENV === 'development',
+  logging: process.env.NODE_ENV === 'development',
   ssl: { rejectUnauthorized: false },
 });

--- a/microservices/user-service/src/config/jwt.config.ts
+++ b/microservices/user-service/src/config/jwt.config.ts
@@ -1,11 +1,8 @@
 import { JwtModuleOptions } from '@nestjs/jwt';
-import { ConfigService } from '@nestjs/config';
 
-export const getJwtConfig = async (
-  configService: ConfigService,
-): Promise<JwtModuleOptions> => ({
-  secret: configService.get<string>('JWT_SECRET', 'your-super-secret-jwt-key'),
+export const getJwtConfig = (): JwtModuleOptions => ({
+  secret: process.env.JWT_SECRET ?? 'your-super-secret-jwt-key',
   signOptions: {
-    expiresIn: configService.get<string>('JWT_EXPIRES_IN', '24h'),
+    expiresIn: process.env.JWT_EXPIRES_IN ?? '24h',
   },
 });

--- a/microservices/user-service/src/filters/http-exception.filter.ts
+++ b/microservices/user-service/src/filters/http-exception.filter.ts
@@ -7,7 +7,7 @@ import {
   HttpStatus,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
-import { ApiResponse } from '../../../../shared/common/interfaces/api-response.interface';
+import { ApiResponse } from '../common/interfaces/api-response.interface';
 
 @Catch()
 export class AllExceptionsFilter implements ExceptionFilter {

--- a/microservices/user-service/src/interceptors/response.interceptor.ts
+++ b/microservices/user-service/src/interceptors/response.interceptor.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
-import { ApiResponse } from '../../../../shared/common/interfaces/api-response.interface';
+import { ApiResponse } from '../common/interfaces/api-response.interface';
 
 @Injectable()
 export class ResponseInterceptor<T>

--- a/microservices/user-service/tsconfig.json
+++ b/microservices/user-service/tsconfig.json
@@ -9,6 +9,7 @@
     "target": "ES2023",
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": "./src",
     "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,

--- a/shared/config/database.config.ts
+++ b/shared/config/database.config.ts
@@ -12,7 +12,7 @@ export const databaseConfigs = {
   postgres: {
     type: 'postgres' as const,
     host: process.env.DATABASE_HOST || 'localhost',
-    port: parseInt(process.env.DATABASE_PORT) || 5432,
+    port: Number(process.env.DATABASE_PORT) || 5432,
     username: process.env.DATABASE_USER || 'postgres',
     password: process.env.DATABASE_PASSWORD || 'postgres123',
     database: process.env.DATABASE_NAME || 'userdb',
@@ -26,7 +26,7 @@ export const databaseConfigs = {
   redis: {
     type: 'redis' as const,
     host: process.env.REDIS_HOST || 'localhost',
-    port: parseInt(process.env.REDIS_PORT) || 6379,
+    port: Number(process.env.REDIS_PORT) || 6379,
     password: process.env.REDIS_PASSWORD || 'redis123',
   },
 };


### PR DESCRIPTION
## Summary
- remove ConfigModule usage in user-service and rely on environment variables
- copy shared utilities in Docker build and mount them through docker-compose

## Testing
- `npm run build`
- `npm test -- --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_68bb985201808333a62b5542e6c48971